### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,3 @@ require (
 )
 
 go 1.15
-
-replace (
-	github.com/xo/usql latest => github.com/tidbcloud/usql latest
-)


### PR DESCRIPTION
```
/Users/ruby/go/src/github.com/tidbcloud/usql/go.mod:79:2: replace github.com/tidbcloud/usql: version "master" invalid: Get "https://proxy.golang.org/github.com/tidbcloud/usql/@v/master.info": dial tcp 216.58.200.81:443: i/o timeout
```